### PR TITLE
Update angular-cli version to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN useradd --user-group --create-home --shell /bin/false app
 ENV HOME=/home/app
 WORKDIR $HOME
 
-RUN npm install -g angular-cli@1.0.0-beta.24 && npm cache clean
+RUN npm install -g @angular/cli && npm cache clean
 
 EXPOSE 4200


### PR DESCRIPTION
Using `angular-cli@1.0.0-beta.24` cause following error on run:
> You have to be inside an ember-cli project in order to use the serve command.

Updating angular-cli to latest version fix it